### PR TITLE
Fixes disable interlude config being ignored

### DIFF
--- a/src/stream/stream.js
+++ b/src/stream/stream.js
@@ -15,10 +15,12 @@ let nextTypeKey = undefined;
 
 const getTypeKey = config => {
   let typeKey = 'radio';
-  const randomNumber = Math.random();
-  const frequency = parseFloat(config.interlude.frequency, 10);
-  if (randomNumber <= frequency) {
-    typeKey = 'interlude';
+  if (config.interlude.enabled) {
+    const randomNumber = Math.random();
+    const frequency = parseFloat(config.interlude.frequency, 10);
+    if (randomNumber <= frequency) {
+      typeKey = 'interlude';
+    }
   }
 
   return typeKey;


### PR DESCRIPTION
Thanks for the great project! Just a small PR here...

Interludes would always be displayed, ignoring the config option to enable/disable. 

This pull request updates the ```getTypeKey``` method so it will check if interludes are enabled before performing the logic to see if an interlude should be played or not. 