### PR TITLE
Windows Config Rewrite

### DIFF
--- a/src/generate/generate.js
+++ b/src/generate/generate.js
@@ -56,13 +56,13 @@ function createDirectoryContents(currentPath, templatePath, newProjectPath) {
       createDirectoryContents(currentPath, `${templatePath}/${file}`, `${newProjectPath}/${file}`);
     }
   });
+}
 
-  // Function to rewrite paths for windows os
-  function windowsChangePaths(currentPath, newProjectPath) {
-    var configPath = path.join(currentPath, newProjectPath, 'config.json');
-    var configContent = fs.readFileSync(configPath, 'utf-8');
-    var rewrittenConfig = configContent.replace(/\.\//g, '/');
-    fs.writeFileSync(configPath, rewrittenConfig);
-    console.log('📁', chalk.magenta(`Successfully rewritten config.json for your system`));
-  }
+// Function to rewrite paths for windows os
+function windowsChangePaths(currentPath, newProjectPath) {
+  var configPath = path.join(currentPath, newProjectPath, 'config.json');
+  var configContent = fs.readFileSync(configPath, 'utf-8');
+  var rewrittenConfig = configContent.replace(/\.\//g, '/');
+  fs.writeFileSync(configPath, rewrittenConfig);
+  console.log('📁', chalk.magenta(`Successfully rewritten config.json for your system`));
 }

--- a/src/generate/generate.js
+++ b/src/generate/generate.js
@@ -62,7 +62,7 @@ function createDirectoryContents(currentPath, templatePath, newProjectPath) {
 function windowsChangePaths(currentPath, newProjectPath) {
   var configPath = path.join(currentPath, newProjectPath, 'config.json');
   var configContent = fs.readFileSync(configPath, 'utf-8');
-  var rewrittenConfig = configContent.replace(/\.\//g, '/');
+  var rewrittenConfig = configContent.replace(/\.\//g, '\\\\');
   fs.writeFileSync(configPath, rewrittenConfig);
   console.log('📁', chalk.magenta(`Successfully rewritten config.json for your system`));
 }

--- a/src/generate/generate.js
+++ b/src/generate/generate.js
@@ -1,6 +1,7 @@
 // Require our dependencies
 const chalk = require('chalk');
 const fs = require('fs-extra');
+const path = require('path');
 
 module.exports = projectName => {
   // Add a default project name if none
@@ -18,6 +19,11 @@ module.exports = projectName => {
 
   // Fill the project diretory with the template
   createDirectoryContents(process.cwd(), `${__dirname}/template`, projectName);
+
+  // Rewrite all ./ to / in the config if running on windows
+  if (process.platform == 'win32') {
+    windowsChangePaths(process.cwd(), projectName);
+  }
 
   console.log(chalk.green(`Project created at: ${newProjectPath} !`), '🎉');
 };
@@ -50,4 +56,13 @@ function createDirectoryContents(currentPath, templatePath, newProjectPath) {
       createDirectoryContents(currentPath, `${templatePath}/${file}`, `${newProjectPath}/${file}`);
     }
   });
+
+  // Function to rewrite paths for windows os
+  function windowsChangePaths(currentPath, newProjectPath) {
+    var configPath = path.join(currentPath, newProjectPath, 'config.json');
+    var configContent = fs.readFileSync(configPath, 'utf-8');
+    var rewrittenConfig = configContent.replace(/\.\//g, '/');
+    fs.writeFileSync(configPath, rewrittenConfig);
+    console.log('📁', chalk.magenta(`Successfully rewritten config.json for your system`));
+  }
 }


### PR DESCRIPTION
This PR refers the issue explained in #45. For now, I just execute a function that manually replaces all ./ to / in the config.json. Maybe we could consider constructing the paths differently with the path module, but for now it shouldn't matter.

@torch2424 maybe consider adding a os-windows flag so I can break up my current windows support investigation into multiple issues without spamming the issues tab.