### PR TITLE
Move colons to config

### DIFF
--- a/src/generate/template/config.json
+++ b/src/generate/template/config.json
@@ -34,7 +34,7 @@
       },
       "artist": {
         "enabled": true,
-        "label": "Artist",
+        "label": "Artist\\: ",
         "font_color": "#FFFFFF",
         "font_border": "#000000",
         "font_size": "10",
@@ -43,7 +43,7 @@
       },
       "album": {
         "enabled": false,
-        "label": "Album",
+        "label": "Album\\: ",
         "font_color": "#FFFFFF",
         "font_border": "#000000",
         "font_size": "10",
@@ -52,7 +52,7 @@
       },
       "song": {
         "enabled": true,
-        "label": "Song",
+        "label": "Song\\: ",
         "font_color": "#FFFFFF",
         "font_border": "#000000",
         "font_size": "10",

--- a/src/stream/stream.js
+++ b/src/stream/stream.js
@@ -190,7 +190,7 @@ module.exports = async (path, config, outputLocation, endCallback, errorCallback
     if (overlayConfigObject.artist && overlayConfigObject.artist.enabled) {
       const itemObject = overlayConfigObject.artist;
       let itemString =
-        `drawtext=text='${itemObject.label}\\: ${metadata.common.artist}'` +
+        `drawtext=text='${itemObject.label}${metadata.common.artist}'` +
         `:fontfile=${fontPath}` +
         `:fontsize=(w * ${itemObject.font_size / 300})` +
         `:bordercolor=${itemObject.font_border}` +
@@ -205,7 +205,7 @@ module.exports = async (path, config, outputLocation, endCallback, errorCallback
     if (overlayConfigObject.album && overlayConfigObject.album.enabled) {
       const itemObject = overlayConfigObject.album;
       let itemString =
-        `drawtext=text='${itemObject.label}\\: ${metadata.common.album}'` +
+        `drawtext=text='${itemObject.label}${metadata.common.album}'` +
         `:fontfile=${fontPath}` +
         `:fontsize=(w * ${itemObject.font_size / 300})` +
         `:bordercolor=${itemObject.font_border}` +
@@ -220,7 +220,7 @@ module.exports = async (path, config, outputLocation, endCallback, errorCallback
     if (overlayConfigObject.song && overlayConfigObject.song.enabled) {
       const itemObject = overlayConfigObject.song;
       let itemString =
-        `drawtext=text='${itemObject.label}\\: ${metadata.common.title}'` +
+        `drawtext=text='${itemObject.label}${metadata.common.title}'` +
         `:fontfile=${fontPath}` +
         `:fontsize=(w * ${itemObject.font_size / 300})` +
         `:bordercolor=${itemObject.font_border}` +


### PR DESCRIPTION
The colons after the label are hardcoded, if you don't want to use a label in the text, you're gonna have to stick with a single colon at the start of the text, so I moved the colon from the code to the config.