### PR TITLE
Dynamic `config.js`, and tons of docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ _For building your own API frontend, please see the [API Documentation](https://
 
 Currently, there are no supported API frontends. However, Contributions are welcome! If you make a `live-stream-radio` frontend, please open an issue and so we can add the project here 😄!
 
+# Other Notable Projects
+
+- [lsr-wrapper](https://github.com/LSRemote/lsr-wrapper) - A Promise based wrapper around the `live-stream-radio` api.
+
 # Compatibility
 
 Currently, this should work under any OS with support for [Node](https://nodejs.org/en/) and [FFMPEG](https://www.ffmpeg.org/). Specifically in the tradition of this project being developed for raspberry pi, formerly as piStreamRadio , this also supports Raspbian as well.

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,8 +1,7 @@
 // Function to verify a key
 const verifyKey = async (getConfig, request) => {
-  
   // Get our returned config
-  config = getConfig();
+  config = await getConfig();
 
   if (!config.api.key) {
     return true;

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,5 +1,9 @@
 // Function to verify a key
-const verifyKey = async (config, request) => {
+const verifyKey = async (getConfig, request) => {
+  
+  // Get our returned config
+  config = getConfig();
+
   if (!config.api.key) {
     return true;
   }
@@ -18,9 +22,9 @@ const verifyKey = async (config, request) => {
 };
 
 // Function to wrap a standard route handler
-const secureRouteHandler = (config, routeHandler) => {
+const secureRouteHandler = (getConfig, routeHandler) => {
   return async (request, reply) => {
-    const keyResponse = await verifyKey(config, request);
+    const keyResponse = await verifyKey(getConfig, request);
     if (keyResponse) {
       return await routeHandler(request, reply);
     } else {

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -45,10 +45,10 @@ const toSafeString = function(string) {
   return string;
 };
 
-module.exports = (fastify, path, stream, config) => {
+module.exports = (fastify, path, stream, getConfig) => {
   fastify.get(
     '/config',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       // Returns full config is "key" is not set, otherwise only return the requested key
       let response;
       if (request.query.key) {
@@ -68,7 +68,9 @@ module.exports = (fastify, path, stream, config) => {
   // Change a setting
   fastify.post(
     '/config',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
+      // We need our actual config here to make sure we are reurning the static json file    
+      const config = require(`${path}/config.json`);
       let response = await changeConfig(path, config, request.body.key, request.body.value);
 
       reply.type('application/json').code(response[0]);

--- a/src/api/endpoints.mdx
+++ b/src/api/endpoints.mdx
@@ -150,7 +150,7 @@ Only one thing played on the stream so far in this history example
 }
 ```
 
-## GET /radio/audio
+## GET /library/audio
 
 ### Description
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -10,14 +10,14 @@ const addConfigRoutes = require('./config.js');
 const addLibraryRoutes = require('./library.js');
 
 let currentStream;
-let currentConfig;
+let currentGetConfig;
 
 // Export our
 module.exports = {
-  start: async (path, config, stream) => {
+  start: async (path, getConfig, stream) => {
     // save a reference to our stream and config
     currentStream = stream;
-    currentConfig = config;
+    currentGetConfig = getConfig;
 
     // Create our base "Hello world" route
     fastify.get('/', async (request, reply) => {
@@ -26,12 +26,14 @@ module.exports = {
     });
 
     // Implement our other routes
-    addStreamRoutes(fastify, path, currentStream, currentConfig);
-    addConfigRoutes(fastify, path, currentStream, currentConfig);
-    addLibraryRoutes(fastify, path, currentStream, currentConfig);
+    addStreamRoutes(fastify, path, currentStream, currentGetConfig);
+    addConfigRoutes(fastify, path, currentStream, currentGetConfig);
+    addLibraryRoutes(fastify, path, currentStream, currentGetConfig);
+
+    const config = getConfig();
 
     await new Promise((resolve, reject) => {
-      fastify.listen(currentConfig.api.port, currentConfig.api.host, (err, address) => {
+      fastify.listen(config.api.port, config.api.host, (err, address) => {
         if (err) {
           reject(err);
         }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -30,7 +30,7 @@ module.exports = {
     addConfigRoutes(fastify, path, currentStream, currentGetConfig);
     addLibraryRoutes(fastify, path, currentStream, currentGetConfig);
 
-    const config = getConfig();
+    const config = await getConfig();
 
     await new Promise((resolve, reject) => {
       fastify.listen(config.api.port, config.api.host, (err, address) => {

--- a/src/api/library.js
+++ b/src/api/library.js
@@ -7,7 +7,7 @@ const supportedFileTypes = require('../supportedFileTypes');
 const getAllAudio = async (path, getConfig) => {
   // Find al of our files with the extensions
   let allFiles = [];
-  const config = getConfig();
+  const config = await getConfig();
   supportedFileTypes.supportedAudioTypes.forEach(extension => {
     allFiles = [...allFiles, ...find.fileSync(extension, `${path}${config.radio.audio_directory}`)];
   });

--- a/src/api/library.js
+++ b/src/api/library.js
@@ -4,9 +4,10 @@ const musicMetadata = require('music-metadata');
 const authService = require('./auth');
 const supportedFileTypes = require('../supportedFileTypes');
 
-const getAllAudio = async (path, config) => {
+const getAllAudio = async (path, getConfig) => {
   // Find al of our files with the extensions
   let allFiles = [];
+  const config = getConfig();
   supportedFileTypes.supportedAudioTypes.forEach(extension => {
     allFiles = [...allFiles, ...find.fileSync(extension, `${path}${config.radio.audio_directory}`)];
   });
@@ -14,8 +15,8 @@ const getAllAudio = async (path, config) => {
   return allFiles;
 };
 
-const getAllAudioWithMetadata = async (path, config) => {
-  const audioFiles = await getAllAudio(path, config);
+const getAllAudioWithMetadata = async (path, getConfig) => {
+  const audioFiles = await getAllAudio(path, getConfig);
 
   const allMetadata = [];
   const metadataPromises = [];
@@ -38,15 +39,15 @@ const getAllAudioWithMetadata = async (path, config) => {
 };
 
 // File to return all of our /radio/* routes
-module.exports = (fastify, path, stream, config) => {
+module.exports = (fastify, path, stream, getConfig) => {
   fastify.get(
     '/library/audio',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       let response;
       if (request.query.include_metadata !== undefined) {
-        response = await getAllAudioWithMetadata(path, config);
+        response = await getAllAudioWithMetadata(path, getConfig);
       } else {
-        response = await getAllAudio(path, config);
+        response = await getAllAudio(path, getConfig);
       }
 
       reply.type('application/json').code(200);

--- a/src/api/stream.js
+++ b/src/api/stream.js
@@ -2,7 +2,7 @@ const historyService = require('../history.service');
 const authService = require('./auth');
 
 // Function to perform all checks before performing route
-const preCheck = (stream, config, fastify, request, reply) => {
+const preCheck = (stream, getConfig, fastify, request, reply) => {
   if (!stream) {
     reply.type('application/json').code(400);
     return {
@@ -14,11 +14,11 @@ const preCheck = (stream, config, fastify, request, reply) => {
 };
 
 // File to return all of our /stream/* routes
-module.exports = (fastify, path, stream, config) => {
+module.exports = (fastify, path, stream, getConfig) => {
   // Get stream status
   fastify.get(
     '/stream',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       reply.type('application/json').code(200);
       return {
         isRunning: stream.isRunning()
@@ -29,8 +29,8 @@ module.exports = (fastify, path, stream, config) => {
   // Start the stream
   fastify.post(
     '/stream/start',
-    authService.secureRouteHandler(config, async (request, reply) => {
-      preCheckResponse = preCheck(stream, config, fastify, request, reply);
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
+      preCheckResponse = preCheck(stream, getConfig, fastify, request, reply);
       if (preCheckResponse) {
         return preCheckResponse;
       }
@@ -49,8 +49,8 @@ module.exports = (fastify, path, stream, config) => {
   // Stop the stream
   fastify.post(
     '/stream/stop',
-    authService.secureRouteHandler(config, async (request, reply) => {
-      preCheckResponse = preCheck(stream, config, fastify, request, reply);
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
+      preCheckResponse = preCheck(stream, getConfig, fastify, request, reply);
       if (preCheckResponse) {
         return preCheckResponse;
       }
@@ -69,8 +69,8 @@ module.exports = (fastify, path, stream, config) => {
   // Restart the stream
   fastify.post(
     '/stream/restart',
-    authService.secureRouteHandler(config, async (request, reply) => {
-      preCheckResponse = preCheck(stream, config, fastify, request, reply);
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
+      preCheckResponse = preCheck(stream, getConfig, fastify, request, reply);
       if (preCheckResponse) {
         return preCheckResponse;
       }
@@ -94,7 +94,7 @@ module.exports = (fastify, path, stream, config) => {
   // Stream History
   fastify.get(
     '/stream/history',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       reply.type('application/json').code(200);
       return {
         history: historyService.getHistory()
@@ -105,35 +105,35 @@ module.exports = (fastify, path, stream, config) => {
   // Returns 405
   fastify.post(
     '/stream',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       reply.type('application/json').code(405);
       return {};
     })
   );
   fastify.get(
     '/stream/start',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       reply.type('application/json').code(405);
       return {};
     })
   );
   fastify.get(
     '/stream/stop',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       reply.type('application/json').code(405);
       return {};
     })
   );
   fastify.get(
     '/stream/restart',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       reply.type('application/json').code(405);
       return {};
     })
   );
   fastify.post(
     '/stream/history',
-    authService.secureRouteHandler(config, async (request, reply) => {
+    authService.secureRouteHandler(getConfig, async (request, reply) => {
       reply.type('application/json').code(405);
       return {};
     })

--- a/src/frontendsAndNotableProjects.mdx
+++ b/src/frontendsAndNotableProjects.mdx
@@ -1,0 +1,17 @@
+---
+name: Frontends & Notable Projects
+route: /frontends-and-notable-projects
+order: 7
+---
+
+# API Frontends
+
+_For building your own API frontend, please see the [API Documentation](https://torch2424.github.io/live-stream-radio/api/frontenddevelopment) 📚 on API Endpoints._
+
+Currently, there are no supported API frontends. However, Contributions are welcome! If you make a `live-stream-radio` frontend, please open an issue and so we can add the project here 😄!
+
+# Other Notable Projects
+
+* [lsr-wrapper](https://github.com/LSRemote/lsr-wrapper) - A Promise based wrapper around the `live-stream-radio` api.
+
+

--- a/src/generate/config.mdx
+++ b/src/generate/config.mdx
@@ -113,3 +113,42 @@ Common Image Objects contain all settings required to display an image.
 }
 ```
 
+## Dynamic Config
+
+It is possible to add extra functionality to how `live-stream-radio` parses your config.json per song. For example, if you would like to build:
+
+* A radio station that plays certain songs during a certain time of day
+* Shows a different title depending on the last song played
+* Uses an API to decide what song to play
+
+This can be done by adding a `config.js` to the root of your project. In other words, in the same root of the project that your `config.json` resides. This `config.js` simply exports a single [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) function, or function that returns a promise, that resolves an object representing a `config.json`. This function takes in a projectPath, and a streamState Object and can use those before deciding any final decisions. **Note:** `config.js` will take precendence over any `config.json`, and it is reccomended that you use your config.json as a fallback and resolved by your `config.js` exported async function.
+
+### Function Definition
+
+**Params**
+
+* path (string) - Absolute path of the current project directory
+
+* streamState (Object) - Object containing various information about the stream
+
+| streamState Field | Usage |
+| - | - |
+| history | History of the activites performed on the stream, recorded in the history service. See [/live-stream-radio/api/endpoints#get-history] |
+
+### Example
+
+So let's take the first example, **A radio station that plays certain songs during a certain time of day**. What we can do is make seperate folders in our project for each hour on a 24 hour time, and use [getHours()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours) to get the current hour of the day.
+
+**config.js**
+
+```js
+module.exports = async (path, streamState) => {
+  let config = require(`${path}config.json`);
+
+  const date = new Date();
+  const currentHour = date.getHours();
+  config.radio.audio_directory = `./my/audio/directory/${currentHour}`;
+
+  return config;
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ if (fs.existsSync(configJsPath)) {
     return config;
   };
 } else if (fs.existsSync(configJsonPath)) {
-  console.log(`${chalk.magenta('Using the config.json at:')} ${configJsPath}`);
+  console.log(`${chalk.magenta('Using the config.json at:')} ${configJsonPath}`);
   // Simply set our config to a function that just returns the static config.json
   getConfig = async () => {
     let configJson = undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,8 @@ if (argv.generate !== undefined) {
 // Start the server
 const chalk = require('chalk');
 
+const historyService = require('./history.service');
+
 // Check if we passed in a base path
 let path = process.cwd();
 if ((argv.start && argv.start.length > 0) || argv._.length > 0) {
@@ -70,12 +72,40 @@ if (lastPathChar != '/') {
 }
 
 // Find if we have a config in the path
-const configPath = `${path}/config.json`;
-let config = undefined;
-try {
-  config = require(configPath);
-} catch (e) {
-  console.log(`${chalk.red('error getting your config.json!')} 😞`);
+const configJsonPath = `${path}/config.json`;
+const configJsPath = `${path}/config.js`;
+let getConfig = undefined;
+// First check if we have a config.js
+if (fs.existsSync(configJsPath)) {
+
+  console.log(`${chalk.green('Using the config.js at:')} ${configJsPath}`);
+  const configExport = require(configJsPath);
+  
+  // Wrap get config in all of our stateful service
+  getConfig = () => {
+    configExport({
+      history: historyService.getHistory(); 
+    }) 
+  }
+} else if (fs.existsSync(configJsonPath)) {
+
+  console.log(`${chalk.magenta('Using the config.json at:')} ${configJsPath}`);
+  // Simply set our config to a function that just returns the static config.json
+  getConfig = () => {
+    let configJson = undefined;
+    try {
+      configJson = require(configJsonPath);
+    } catch (e) {
+      console.log(`${chalk.red('error reading the config.json!')} 😞`);
+      console.log(e.message);
+      process.exit(1);
+    }
+
+    return configJson;
+  }
+} else {
+  // Tell them could not find a config file
+  console.log(`${chalk.red('error did not find a config.json at:')} ${configJsonPath} 😞`);
   console.log(e.message);
   process.exit(1);
 }
@@ -87,13 +117,12 @@ const startRadioTask = async () => {
 
   // Start the api
   const api = require('./api/index.js');
-  await api.start(path, config, stream);
+  await api.start(path, getConfig, stream);
 
   // Set our number of history items
-  const historyService = require('./history.service');
-  historyService.setNumberOfHistoryItems(config.api.number_of_history_items);
+  historyService.setNumberOfHistoryItems(getConfig().api.number_of_history_items);
 
   // Start our stream
-  await stream.start(path, argv.output);
+  await stream.start(path, getConfig, argv.output);
 };
 startRadioTask();

--- a/src/index.js
+++ b/src/index.js
@@ -82,10 +82,10 @@ if (fs.existsSync(configJsPath)) {
   const configExport = require(configJsPath);
 
   // Wrap get config in all of our stateful service
-  getConfig = () => {
+  getConfig = async () => {
     let config = undefined;
     try {
-      config = configExport(path, {
+      config = await configExport(path, {
         history: historyService.getHistory()
       });
     } catch (e) {
@@ -99,7 +99,7 @@ if (fs.existsSync(configJsPath)) {
 } else if (fs.existsSync(configJsonPath)) {
   console.log(`${chalk.magenta('Using the config.json at:')} ${configJsPath}`);
   // Simply set our config to a function that just returns the static config.json
-  getConfig = () => {
+  getConfig = async () => {
     let configJson = undefined;
     try {
       configJson = require(configJsonPath);
@@ -128,7 +128,8 @@ const startRadioTask = async () => {
   await api.start(path, getConfig, stream);
 
   // Set our number of history items
-  historyService.setNumberOfHistoryItems(getConfig().api.number_of_history_items);
+  const config = await getConfig();
+  historyService.setNumberOfHistoryItems(config.api.number_of_history_items);
 
   // Start our stream
   await stream.start(path, getConfig, argv.output);

--- a/src/raspberryPi.mdx
+++ b/src/raspberryPi.mdx
@@ -1,39 +1,16 @@
 ---
 name: Raspberry Pi
 route: /raspberry-pi
-order: 999
+order: 6
 ---
 
 # Raspberry Pi
 
-This page contains tips for setting up `live-stream-radio` on a raspberry pi. If you have any performance issues, or are not comfortable using Node.js, feel free to use the older (no longer updated) version of the project, [piStreamRadio v1.2.0](https://github.com/torch2424/live-stream-radio/tree/1.2.0).
+This page contains tips for setting up `live-stream-radio` on a raspberry pi. If you have any performance issues, or are not comfortable using Node.js, feel free to use the older (no longer updated) version of the project, [piStreamRadio v1.2.0](https://github.com/torch2424/live-stream-radio/tree/1.2.0). Please read over the [CLI Getting Started](/cli/getting-started) to have context on what steps are required, and how these steps streamline the usual install process for Raspberry Pis.
 
 ### FFmpeg Installation
 
-Installing live-stream-radio on a raspberry pi follows the same proedures from the [CLI Getting Started](/cli/getting-started), however, there is a more streamlined way of getting FFmpeg installed. Since the project was formerly called `piStreamRadio`, we have a FFmpeg build that can still be downloaded and used directly. First, you need to install the build dependencies:
-
-```
-# Install some shared libs
-sudo apt-get install -y gifsicle \
-       autoconf automake build-essential libass-dev \
-       libfreetype6-dev libtheora-dev libtool libvorbis-dev \
-       pkg-config texinfo zlib1g-dev libgnutls28-dev \
-       librtmp-dev libssl-dev libx264-dev libasound2-dev
-
-# Install an audio decoder
-wget http://ftp.us.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac-dev_0.1.3+20140816-2_armhf.deb
-wget http://ftp.us.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac0_0.1.3+20140816-2_armhf.deb
-
-# Install our audio decoders
-sudo dpkg -i libfdk-aac0_0.1.3+20140816-2_armhf.deb
-sudo dpkg -i libfdk-aac-dev_0.1.3+20140816-2_armhf.deb
-
-# Clean up the .deb files for the decoders
-rm libfdk-aac0_0.1.3+20140816-2_armhf.deb
-rm libfdk-aac-dev_0.1.3+20140816-2_armhf.deb
-```
-
-Next, you can download `piStreamRadio` 1.2.0 [ffmpeg raspberry pi build](https://github.com/torch2424/live-stream-radio/blob/1.2.0/ffmpeg/ffmpeg). **Remember where this file is saved, as it will be used in the config.json later**.
+Installing live-stream-radio on a raspberry pi follows the same proedures from the [CLI Getting Started](/cli/getting-started), however, there is a more streamlined way of getting FFmpeg installed. Since the project was formerly called `piStreamRadio`, we have an old script to compile FFmpeg for you on the [piStreamRadio v1.2.0 `additionalScripts/compileFFmpeg.sh`](https://github.com/torch2424/live-stream-radio/blob/1.2.0/additionalScripts/compileFFmpeg.sh). Re-iterating from the [CLI Getting Started](/cli/getting-started), **Note: this project requires FFmpeg version 4.2.0 or greater in order to ensure the best performance. [Please see this issue for explanation](https://github.com/torch2424/live-stream-radio/issues/78)**.
 
 ### Configuring your project
 

--- a/src/stream/gettingstarted.mdx
+++ b/src/stream/gettingstarted.mdx
@@ -14,10 +14,11 @@ Simply download nvm from [this (Mac/Linux)](https://github.com/creationix/nvm) o
 `nvm install --lts`
 
 ### FFmpeg
-Next, you have to donwload or compile the latest version of [FFmpeg](http://ffmpeg.org/). It specifically needs to be compiled with [libfreetype](https://ffmpeg.org/ffmpeg-filters.html#drawtext) so we can draw text within the stream image. You can either add the folder of your ffmpeg binaries to your system's PATH or directly put the path to them in the config file.
+Next, you have to download or compile the latest version of [FFmpeg](http://ffmpeg.org/). It specifically needs to be compiled with [libfreetype](https://ffmpeg.org/ffmpeg-filters.html#drawtext) so we can draw text within the stream image. You can either add the folder of your ffmpeg binaries to your system's PATH or directly put the path to them in the config file. **Note: this project requires FFmpeg version 4.2.0 or greater in order to ensure the best performance. [Please see this issue for explanation](https://github.com/torch2424/live-stream-radio/issues/78)** 
 
 #### Downloading FFmpeg
-If you are lucky, you can find hosted static builds for your operating system from [this](https://ffmpeg.zeranoe.com/builds/) resource. However, some used FFmpeg filters in the project require other libraries that may not be in pre-compiled builds. Thus, you may want to try compiling FFmpeg yourself in the following steps. 
+
+We have a mock release page, where we can share Pre-compiled FFmpeg builds that we confirm work well with `live-stream-radio`. Check out the [FFmpeg pre-compiled builds here](https://github.com/torch2424/live-stream-radio/releases/tag/ffmpeg-builds).
 
 #### Compiling FFmpeg
 Please check out the [FFmpeg Compilation Guide](https://trac.ffmpeg.org/wiki/CompilationGuide) for a more detailled guide. Again, please check that you build FFmpeg with the libfreetype module. If you using macOS, building ffmpeg may be as easy as running `brew install ffmpeg --with-freetype` on your terminal.

--- a/src/stream/index.js
+++ b/src/stream/index.js
@@ -66,7 +66,7 @@ const moduleExports = {
     }
 
     // Get our config, this will refresh on every song
-    let config = currentGetConfig();
+    let config = await currentGetConfig();
 
     //  Build our stream outputs
     if (!currentOutputLocation) {

--- a/src/stream/index.js
+++ b/src/stream/index.js
@@ -5,6 +5,9 @@ const stream = require('./stream.js');
 // Save our current path
 let currentPath = undefined;
 
+// Save our current getConfig cuntion
+let currentGetConfig = undefined;
+
 // Save our current outputlocation
 let currentOutputLocation = undefined;
 
@@ -43,31 +46,27 @@ const endCallback = () => {
 
 // Create our exports
 const moduleExports = {
-  start: async (path, outputLocation) => {
+  start: async (path, getConfig, outputLocation) => {
     console.log('\n');
     chalkLine.white();
     console.log('\n');
     console.log(`${chalk.green('Starting stream!')} 🛠️`);
     console.log('\n');
 
-    // Save our passed params for later use
     if (path) {
       currentPath = path;
     }
+
+    if (getConfig) {
+      currentGetConfig = getConfig;
+    }
+
     if (outputLocation) {
       currentOutputLocation = outputLocation;
     }
 
     // Get our config, this will refresh on every song
-    const configPath = `${currentPath}/config.json`;
-    let config;
-    try {
-      config = require(configPath);
-    } catch (e) {
-      console.log(`${chalk.red('error getting your config.json!')} 😞`);
-      console.log(e.message);
-      process.exit(1);
-    }
+    let config = getConfig();
 
     //  Build our stream outputs
     if (!currentOutputLocation) {

--- a/src/stream/index.js
+++ b/src/stream/index.js
@@ -66,7 +66,7 @@ const moduleExports = {
     }
 
     // Get our config, this will refresh on every song
-    let config = getConfig();
+    let config = currentGetConfig();
 
     //  Build our stream outputs
     if (!currentOutputLocation) {


### PR DESCRIPTION
closes #87 
closes #86 
closes #48 
closes #82

This adds support for a `config.js` at the root of projects, and can dynamically and asynchronously return configs before starting the next song 😄 

This also closes all of the docs issues mentioned above

@AndreasWebdev Added you as a reviewer if you are interested in that kind of thing, no pressure if you are busy, I can go ahead and merge if so. But please feel free to object to my idea of #87 , just got so excited on it I just went ahead and implemented haha! I wrote docz on it, and attached the docs I wrote, so hopefully that makes things more clear 😄 

# Screenshots
<img width="1280" alt="screen shot 2018-10-10 at 1 32 01 am" src="https://user-images.githubusercontent.com/1448289/46723399-98dc4580-cc2c-11e8-83e6-9172fd09ac35.png">
<img width="1280" alt="screen shot 2018-10-10 at 1 37 37 am" src="https://user-images.githubusercontent.com/1448289/46723653-2cae1180-cc2d-11e8-9cf7-c52b44b744e6.png">

**When you do have a `config.js`**
<img width="640" alt="screen shot 2018-10-10 at 12 13 20 am" src="https://user-images.githubusercontent.com/1448289/46723400-98dc4580-cc2c-11e8-98c6-3864952b6aa5.png">

**When you don't have a `config.js`, but have a `config.json`**
<img width="673" alt="screen shot 2018-10-10 at 1 39 38 am" src="https://user-images.githubusercontent.com/1448289/46723740-641cbe00-cc2d-11e8-9a57-6a9dfa43228b.png">

**Dynamically generated radio titles with the `config.js`**
<img width="851" alt="screen shot 2018-10-10 at 12 14 49 am" src="https://user-images.githubusercontent.com/1448289/46723401-98dc4580-cc2c-11e8-9864-557be7ffb247.png">
<img width="966" alt="screen shot 2018-10-10 at 12 20 57 am" src="https://user-images.githubusercontent.com/1448289/46723402-9974dc00-cc2c-11e8-8b90-160755c55ac6.png">
